### PR TITLE
feat: navigate mode for hand tool

### DIFF
--- a/src/custom/drawing_tool.ts
+++ b/src/custom/drawing_tool.ts
@@ -86,6 +86,11 @@ export class DrawingTool extends RefCounted {
     } else if (promptMode === "lasso") {
       const url = this.makeLassoCursor();
       cursor = `url("${url}") 7 25, default`;
+    } else if (mode === "navigate") {
+      // Hand tool: drag-to-pan. Use grab as the static cursor; the
+      // mousedown/mouseup listeners in drawing_tool_handler swap to
+      // grabbing while a drag is in progress.
+      cursor = "grab";
     } else if (mode) {
       cursor = "crosshair";
     }

--- a/src/custom/drawing_tool_handler.ts
+++ b/src/custom/drawing_tool_handler.ts
@@ -236,6 +236,20 @@ function isOnDataPanel(e: MouseEvent): boolean {
   return !!(e.target as HTMLElement).closest(DATA_PANEL_SELECTOR);
 }
 
+// Hand tool: temporarily override the grab cursor (set by drawing_tool.ts
+// applyMode when activeMode === "navigate") to grabbing while a drag is
+// in progress. Uses !important to win against drawing_tool's periodic
+// cursor enforcement timer.
+function setNavigateGrabbing(grabbing: boolean) {
+  document.querySelectorAll(DATA_PANEL_SELECTOR).forEach((el) => {
+    if (grabbing) {
+      (el as HTMLElement).style.setProperty("cursor", "grabbing", "important");
+    } else {
+      (el as HTMLElement).style.removeProperty("cursor");
+    }
+  });
+}
+
 function voxelPoint(viewer: any): StrokePoint {
   const p = viewer?.mouseState?.position;
   if (!p || p.length < 3) return { x: NaN, y: NaN, z: NaN };
@@ -477,6 +491,9 @@ export function setupDrawingToolMessageHandler(drawingTool: DrawingTool) {
   const onMouseDown = (e: MouseEvent) => {
     const mode = drawingTool.activeMode.value;
     const promptMode = drawingTool.promptMode.value;
+    // Hand tool (navigate mode): explicit user intent to pan. Don't intercept
+    // — let Neuroglancer's default navigation handlers take the mousedown.
+    if (mode === "navigate") return;
     const promptPolarity = drawingTool.promptPolarity.value;
     if ((!mode && !promptMode) || e.button !== 0) return;
 
@@ -709,6 +726,13 @@ export function setupDrawingToolMessageHandler(drawingTool: DrawingTool) {
     const mode = drawingTool.activeMode.value;
     const promptMode = drawingTool.promptMode.value;
 
+    // Hand tool (navigate mode): explicit user intent to pan. Skip the
+    // block entirely so NG's default pan handler can take the mousedown.
+    if (mode === "navigate") {
+      setNavigateGrabbing(true); // grab → grabbing during drag
+      return;
+    }
+
     // If no drawing/prompt mode is active, block ALL clicks to prevent navigation
     if (!mode && !promptMode) {
       e.preventDefault();
@@ -727,6 +751,8 @@ export function setupDrawingToolMessageHandler(drawingTool: DrawingTool) {
   // Block keyboard navigation when locked (arrow keys, etc.)
   container.addEventListener("keydown", (e: KeyboardEvent) => {
     if (!lockedBBox) return;
+    // Hand tool: explicit nav intent, allow nav keys.
+    if (drawingTool.activeMode.value === "navigate") return;
 
     // Block navigation keys on slice panels
     const navKeys = ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "PageUp", "PageDown"];
@@ -738,6 +764,13 @@ export function setupDrawingToolMessageHandler(drawingTool: DrawingTool) {
       e.stopPropagation();
     }
   }, { capture: true });
+
+  // Hand tool cursor toggle: restore grab when drag ends.
+  container.addEventListener("mouseup", () => {
+    if (drawingTool.activeMode.value === "navigate") {
+      setNavigateGrabbing(false);
+    }
+  });
 
   // -- Redraw locked indicator on resize ------------------------------------
   let resizeTimeout: ReturnType<typeof setTimeout> | null = null;


### PR DESCRIPTION
## Summary

Add `navigate` value to the drawing-tool `activeMode` channel — primitive for a React-side Hand tool that lets drag-pan through even when the view is locked. 38 lines, 2 files, no new message types.

## Changes

- `drawing_tool.ts` — when `activeMode === "navigate"`, set data-panel cursor to `grab`
- `drawing_tool_handler.ts`:
  - `onMouseDown` and the lock-view click blocker early-return for `navigate` so NG's default pan handler takes the mousedown; capture-phase listener flips cursor to `grabbing` during drag
  - `keydown` blocker also exits early for `navigate` (arrow keys for nav)
  - New `mouseup` listener restores `grab` after drag

## Motivation

After locking the view, drag-pan is blocked — left-click goes to the active drawing tool, or is blocked entirely if no tool is selected. When a locked region fills the viewport there is no way to pan. The React side wants a Hand button (Photoshop pattern); this PR is the NG-side primitive it relies on.

## Test plan

- Local SAVAII Hand button toggles `drawing_mode_change=navigate`; cursor goes grab on hover, grabbing on drag, image pans even when locked
- Brush / point prompt / flood-fill modes unchanged (regression check)
- Pre-lock pan works in all existing modes